### PR TITLE
Update TabControl layout to stretch tab headers

### DIFF
--- a/Controls/TabControls/TabControls.xaml
+++ b/Controls/TabControls/TabControls.xaml
@@ -9,6 +9,16 @@
                     SelectedItem="{Binding SelectedTab}"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch">
+            <TabControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <UniformGrid Rows="1" />
+                </ItemsPanelTemplate>
+            </TabControl.ItemsPanel>
+            <TabControl.ItemContainerStyle>
+                <Style TargetType="TabItem">
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                </Style>
+            </TabControl.ItemContainerStyle>
             <TabControl.ItemTemplate>
                 <DataTemplate DataType="{x:Type vm:TabItemViewModel}">
                     <StackPanel Orientation="Horizontal">


### PR DESCRIPTION
## Summary
- set UniformGrid in TabControl headers
- stretch TabItem content so headers fill remaining width

## Testing
- `dotnet build` *(fails: NETSDK1045: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687bcd889f24832687db8c5931874980