### PR TITLE
Enable text editor in tab content template

### DIFF
--- a/Controls/TabControls/TabControls.xaml
+++ b/Controls/TabControls/TabControls.xaml
@@ -17,13 +17,11 @@
                     </StackPanel>
                 </DataTemplate>
             </TabControl.ItemTemplate>
-<!--
             <TabControl.ContentTemplate>
                 <DataTemplate DataType="{x:Type vm:TabItemViewModel}">
-                    <editor:TextEditor Text="{Binding Text, Mode=TwoWay}" />
+                    <editor:TextEditor Text="{Binding Text, Mode=TwoWay}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
                 </DataTemplate>
             </TabControl.ContentTemplate>
--->
         </TabControl>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- uncomment the `TabControl.ContentTemplate` so each tab hosts a `TextEditor`
- ensure the editor stretches to fill the available space

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bcd92ab5c83268038926ab5caae3b