### PR TITLE
Fix close tab binding

### DIFF
--- a/Controls/TabControls/TabControls.xaml
+++ b/Controls/TabControls/TabControls.xaml
@@ -13,7 +13,9 @@
                 <DataTemplate DataType="{x:Type vm:TabItemViewModel}">
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Text="{Binding Header}" />
-                        <Button Content="×" Command="{Binding CloseTabCommand}" />
+                        <Button Content="×"
+                                Command="{Binding DataContext.CloseTabCommand, RelativeSource={RelativeSource AncestorType=local:TabControls}}"
+                                CommandParameter="{Binding}" />
                     </StackPanel>
                 </DataTemplate>
             </TabControl.ItemTemplate>

--- a/Controls/TabControls/TabControls.xaml.cs
+++ b/Controls/TabControls/TabControls.xaml.cs
@@ -53,7 +53,7 @@ namespace Controls{
             SelectedTab = Tabs[0];
 
             AddTabCommand = new RelayCommand(_ => AddTab());
-            CloseTabCommand = new RelayCommand(_ => CloseTab(), _ => Tabs.Count > 2); // 追加用タブを除外
+            CloseTabCommand = new RelayCommand(param => CloseTab(param as TabItemViewModel), _ => Tabs.Count > 2); // 追加用タブを除外
 
             DataContext = this;
         }
@@ -65,11 +65,16 @@ namespace Controls{
             SelectedTab = tab;
         }
 
-        private void CloseTab(){
-            if (SelectedTab == null || Tabs.Count <= 2) return; // 追加用タブを除外
-            int idx = Tabs.IndexOf(SelectedTab);
-            Tabs.Remove(SelectedTab);
-            if (Tabs.Count > 1){
+        private void CloseTab(TabItemViewModel? tab){
+            if (tab == null || Tabs.Count <= 2) return; // 追加用タブを除外
+
+            int idx = Tabs.IndexOf(tab);
+            if (idx < 0) return;
+
+            bool wasSelected = SelectedTab == tab;
+            Tabs.Remove(tab);
+
+            if (wasSelected && Tabs.Count > 1){
                 SelectedTab = Tabs[Math.Max(0, idx - 1)];
             }
         }


### PR DESCRIPTION
## Summary
- update CloseTab button binding to use ancestor command and pass tab item
- accept the tab item as a parameter in CloseTab

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bcd9837b08326857fbf10f3b8a8ff