### PR TITLE
Remove unused tabs field

### DIFF
--- a/Controls/TabControls/TabControls.xaml.cs
+++ b/Controls/TabControls/TabControls.xaml.cs
@@ -8,7 +8,6 @@ using Utils;
 namespace Controls{
     // タブの追加・削除・選択のみを管理するコントロール。
     public partial class TabControls : UserControl{
-        private ObservableCollection<TabItemViewModel> tabs { get; } = new ObservableCollection<TabItemViewModel>();
 
         public TabItemViewModel SelectedTab{
             get { return (TabItemViewModel)GetValue(SelectedTabProperty); }


### PR DESCRIPTION
## Summary
- remove an unused `tabs` field from `TabControls`

## Testing
- `dotnet build` *(fails: `command not found`)*
- `apt-get update` *(fails due to blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_687bcd9b45c883268d9534faed9fa48c