### PR TITLE
Remove duplicate partial class

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -6,8 +6,3 @@ namespace JsonEditor
     {
     }
 }
-/// </summary>
-public partial class App : Application
-{
-}
-


### PR DESCRIPTION
## Summary
- clean up `App.xaml.cs` by removing a stray partial class definition

## Testing
- `dotnet build JsonEditor.sln` *(fails: NETSDK1045, SDK 8.0 doesn't support .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687bcda0b41c8326bd2af27acf748d06