### PR TITLE
Hide text editor in plus tab

### DIFF
--- a/Controls/TabControls/TabControls.xaml
+++ b/Controls/TabControls/TabControls.xaml
@@ -35,7 +35,15 @@
             </TabControl.ItemTemplate>
             <TabControl.ContentTemplate>
                 <DataTemplate DataType="{x:Type vm:TabItemViewModel}">
-                    <editor:TextEditor Text="{Binding Text, Mode=TwoWay}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
+                    <editor:TextEditor x:Name="Editor"
+                                      Text="{Binding Text, Mode=TwoWay}"
+                                      HorizontalAlignment="Stretch"
+                                      VerticalAlignment="Stretch" />
+                    <DataTemplate.Triggers>
+                        <DataTrigger Binding="{Binding Header}" Value="＋">
+                            <Setter TargetName="Editor" Property="Visibility" Value="Collapsed" />
+                        </DataTrigger>
+                    </DataTemplate.Triggers>
                 </DataTemplate>
             </TabControl.ContentTemplate>
         </TabControl>

--- a/JsonEditor.csproj
+++ b/JsonEditor.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net9.0-windows</TargetFramework>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>


### PR DESCRIPTION
## Summary
- allow building on Linux by enabling Windows targeting
- hide the text editor for the `＋` tab

## Testing
- `dotnet build JsonEditor.csproj -clp:ErrorsOnly`

------
https://chatgpt.com/codex/tasks/task_e_687bd904a69883269a15988da45056a4